### PR TITLE
Handle invalid UTF-8 characters sequences

### DIFF
--- a/lib/adlint/source.rb
+++ b/lib/adlint/source.rb
@@ -101,6 +101,7 @@ module AdLint #:nodoc:
     def read_content(fpath)
       cont = IO.read(fpath, mode: "rb", encoding: @fenc || "binary")
       cont = cont.byteslice(3..-1) if cont.byteslice(0..2).bytes == UTF_8_BOM
+      cont = cont.encode("UTF-8", 'binary', invalid: :replace, undef: :replace, replace: '')
 
       if cont =~ /\r/
         notify_cr_at_eol_found(Location.new(fpath))


### PR DESCRIPTION
While trying to analyze the source code of Pidgin with Adlint I got the
following error (with subsequent program termination):

```
:::fatal error:core:X0001:ERR:X99:An unknown exception `ArgumentError : invalid byte sequence in UTF-8' is found.
GNUmakefile:628: recipe for target 'pidgin/gtkicon-theme.c.met.csv' failed
make: *** [pidgin/gtkicon-theme.c.met.csv] Error 4
```

The stack trace in the log indicated that the issue was triggered at
line
https://github.com/sjas/adlint/blob/master/lib/adlint/source.rb#L105
because for some reason invalid UTF-8 sequences were getting fetched.

I therefore applied a simple patch to ignore the invalid sequences. This
fixes the issue for me.

Signed-off-by: tomas <tomasbortoli@gmail.com>